### PR TITLE
Improve battle statistics and fitness calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,26 @@ This object is sent to the bot each tick and the bot uses that to make it's next
 
 You can only have a maximum of 5 bullets on the screen at once and they are destroyed when they hit the opponent or wall. Each player has 5 lives. 
 
+### How is bot fitness calculated?
+
+Bot fitness is used to determine what Species go on to produce children vs those that die out. After each battle the fitness is calculated for Bot 1 with the following calculation:
+
+First the fitness is initialized to the generation number of the species, this gives genomes a little boost to account for battles being harder as time goes on. A bot with 100 fitness in generation 500 is probably much better than one with 100 fitness in generation 5.
+
+The bot then gets +20 fitness for each hit on the opponent.
+
+If the bot lost the battle it gets +1 fitness for each second it survived.
+
+If the bot won the battle it gains:
+
+- +1 fitness for each second it had left until maxRoundTime (60 seconds by default), to reward it for winning quickly.
+- +10 fitness for each life it had left.
+- +100 fitness for winning.
+
+Only Bot1 gets a fitness score and contributes to the genome/species overall fitness. Bot 2 is simply a random opponent to fight against and is discarded at the end of the battle.
+
+Bots play 5 battles (versus a random genome each time) in each Round. The fitness from each battle is summed to get the overall fitness of the genome for species culling/reproduction.
+
 ### How does the bot brain map work?
 
 When the bot receives input from the battleground it takes those player and bullet positions and turns

--- a/README.md
+++ b/README.md
@@ -67,6 +67,19 @@ To watch a battle between two trained AI's you can do the following:
 - Open [http://localhost:1337](http://localhost:1337) in your browser.
 - Select the name of the species you trained in Headless training. The list is sorted by date, so it's probably the first item.
 
+#### Battle Statistics
+
+In the watch mode you'll see there are battle statistics in the bottom right. These are:
+
+- Generation - The current generation number you are watching. Bots play in generations and each genome plays 5 battles per generation.
+- MaxFitness - The fitness of the most fit species in this generation.
+
+Competitor Details
+
+- Previous Fitness - The fitness of this genome in the last generation (total fitness over all 5 games added up). `New` means this genome is a child that was just created and so didn't battle last generation.
+- Current Fitness - The total fitness the genome has gained in battles in this generation. Starts at 0 and after each battle the results of that battle are used to calculate the genome fitness and add it to this number. See the "How is bot fitness calculated?" section of this README for more information.
+
+
 ## Configuration Options
 
 All config options are stored in the file `config/default.json`

--- a/dist/index.html
+++ b/dist/index.html
@@ -38,9 +38,11 @@
                 <p>Max Fitness: {{maxFitness}}</p>
                 <h3>Competitor Details</h3>
                 <h4>Red Bot</h4>
-                <p>Fitness: {{bot1Stats.fitness}}</p>
+                <p>Previous Fitness: {{bot1Info.lastFitness}}</p>
+                <p>Current Fitness: {{bot1Info.fitness}}</p>
                 <h4>Blue Bot</h4>
-                <p>Fitness: {{bot2Stats.fitness}}</p>
+                <p>Previous Fitness: {{bot2Info.lastFitness}}</p>
+                <p>Current Fitness: {{bot2Info.fitness}}</p>
             </div>
         </div>
     </div>

--- a/src/coordinator.js
+++ b/src/coordinator.js
@@ -105,12 +105,7 @@ function startRound(totalGenerations, genome1, genome2, callback) {
     });
 
     function handleResults(results) {
-        let botFitness = Math.min(60, Math.floor(results.totalTime)) + ((5 - results.bot2.lives) * 20)
-        if (results.winner == 1) {
-            botFitness += results.bot1.lives * 10;
-            botFitness += 150;
-        }
-        log.debug("Bot fitness is: ", botFitness);
+        let botFitness = Trainer.calculateBotFitnessFromResults(results, totalGenerations);
         genome1.addFitness(botFitness);
         worker.kill();
         return callback(results);

--- a/src/genome.js
+++ b/src/genome.js
@@ -82,6 +82,7 @@ export default class Genome {
             step: config.stepSize
         };
         this.fitness = 0;
+        this.lastFitness = 0;
         this.globalRank = 0;
         this.initializeNeurons();
         this.maxNeuron = INPUT_NEURONS;
@@ -111,7 +112,8 @@ export default class Genome {
         const genome = new Genome();
         genome.mutationRates = Object.assign({}, data.mutationRates);
         genome.maxNeuron = data.maxNeuron;
-        genome.fitness = data.fitness;
+        genome.fitness = 0;
+        genome.lastFitness = data.fitness;
 
         /** Load all the genes into the genome first */
         data.genes.forEach((geneData) => {
@@ -150,7 +152,8 @@ export default class Genome {
      */
     getStats() {
         return {
-            fitness: this.fitness
+            fitness: this.fitness,
+            lastFitness: this.lastFitness
         }
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -40,6 +40,18 @@ var app = new Vue({
         },
         maxFitness() {
             return this.speciesData.maxFitness;
+        },
+        bot1Info() {
+            return {
+                lastFitness: this.bot1Stats.lastFitness || "NEW",
+                fitness: this.bot1Stats.fitness
+            }
+        },
+        bot2Info() {
+            return {
+                lastFitness: this.bot2Stats.lastFitness || "NEW",
+                fitness: this.bot2Stats.fitness
+            }
         }
     },
     async mounted() {

--- a/src/index.js
+++ b/src/index.js
@@ -39,12 +39,7 @@ var app = new Vue({
             return this.speciesData.totalGenerations;
         },
         maxFitness() {
-            return this.speciesData.species.reduce((currentMax, species) => {
-                if (species.maxFitness > currentMax) {
-                    return species.maxFitness;
-                }
-                return currentMax;
-            }, 0);
+            return this.speciesData.maxFitness;
         }
     },
     async mounted() {
@@ -101,24 +96,8 @@ function battle(existingSpecies) {
     const battleground = new Battleground()
     battleground.addBots(bot1, bot2);
     battleground.start((results) => {
-        log.info("Battle results: ", results);
-
-        const maxRoundTime = config.maxRoundTime;
-
-        /* Give the bot an initial fitness of 20 points for each life it took off the opponent */
-        let botFitness =  ((5 - bot2.lives) * 20);
-        if (results.winner == 1) {
-            /* If the bot won it gets bonus fitness the quicker it won */
-            botFitness += maxRoundTime - Math.min(maxRoundTime, Math.floor(results.totalTime))
-            /* The bot gets 10 fitness points for each life it had left at the end */
-            botFitness += bot1.lives * 10;
-            /* The bot gets bonus fitness for winning */
-            botFitness += 150;
-        } else {
-            /* If the bot lost it gets bonus fitness for the longer it survived */
-            botFitness += Math.min(maxRoundTime, Math.floor(results.totalTime))
-        }
-        log.debug("Bot fitness is: ", botFitness);
+        /* Calculate the bots fitness using the trainer method */
+        const botFitness =  Trainer.calculateBotFitnessFromResults(results, trainer.totalGenerations);
 
         /**
          * Add the fitness for this round to the bot. Then increase played rounds as each bot only 
@@ -128,7 +107,6 @@ function battle(existingSpecies) {
         bot1.genome.totalRounds++;
 
         const roundsRemaining = trainer.getTotalRoundsRemaining() 
-        log.info("Round Complete, " + roundsRemaining + " rounds remaining");
         if (roundsRemaining <= 0) {
             trainer.newGeneration();
         }

--- a/src/species.js
+++ b/src/species.js
@@ -26,7 +26,7 @@ export default class Species {
         genomes.forEach((genomeData) => {
             const genome = Genome.loadFromJSON(genomeData);
             species.genomes.push(genome);
-        })
+        });
         return species;
     }
 
@@ -155,6 +155,7 @@ export default class Species {
      */
     resetFitness() {
         this.genomes.forEach((genome) => {
+            genome.lastFitness = genome.fitness;
             genome.fitness = 0;
         });
     }


### PR DESCRIPTION
- Consolidate fitness calculation into one location, it was previously
separate when running battles client side vs in browser.
- Add +n fitness for the generation the genome is in, as battles get
harder over time.
- Lower winning fitness boost from 150 to 100.
- Add README section on how fitness is calculated after battles.
- When loading genomes from JSON always set their fitness to 0 so they
don't start with an advantage.
- Add lastFitness which keeps track of a genomes fitness in the last
round.
- Display last and current fitness as battle statistics to make more
sense and have better correlation with maxFitness.
- Add information about battle statistics to the README.

