### PR TITLE
Fix Webpack 5 and Windows build compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "main": "src/index.js",
   "scripts": {
-    "start": "npm run compile-browser >/dev/null && node server.js",
+    "start": "npm run compile-browser && node server.js",
     "test": "echo \"Error: no test specified\" && exit 1",
     "compile-browser": "npx webpack --mode production",
     "compile-node": "npx babel -d dist/ src",

--- a/server.js
+++ b/server.js
@@ -28,6 +28,53 @@ async function filterAsync(array, callbackfn) {
   return array.filter((value, index) => filterMap[index]);
 }
 
+function getLatestGeneration(files) {
+  const genNumMatch = /generation-([0-9]+)-species/;
+  return files.reduce((latestGeneration, file) => {
+    const match = file.match(genNumMatch);
+    if (!match) {
+      return latestGeneration;
+    }
+
+    const generationNumber = parseInt(match[1], 10);
+    if (Number.isNaN(generationNumber)) {
+      return latestGeneration;
+    }
+
+    if (latestGeneration === null || generationNumber > latestGeneration) {
+      return generationNumber;
+    }
+
+    return latestGeneration;
+  }, null);
+}
+
+function getLatestGenerationFile(files) {
+  const genNumMatch = /generation-([0-9]+)-species/;
+  return files.reduce((latestFile, file) => {
+    const match = file.match(genNumMatch);
+    if (!match) {
+      return latestFile;
+    }
+
+    const generationNumber = parseInt(match[1], 10);
+    if (Number.isNaN(generationNumber)) {
+      return latestFile;
+    }
+
+    if (!latestFile) {
+      return file;
+    }
+
+    const latestGenerationNumber = parseInt(latestFile.match(genNumMatch)[1], 10);
+    if (generationNumber > latestGenerationNumber) {
+      return file;
+    }
+
+    return latestFile;
+  }, null);
+}
+
 router
   .get('/species', async (ctx) => {
     const folders = await fs.readdir(speciesFolder);
@@ -38,15 +85,7 @@ router
     const result = foldersWithFiles.map(async (folder) => { 
       const folderStats = await fs.stat(p.join(speciesFolder, folder)); 
       const files = await fs.readdir(p.join(speciesFolder, folder));
-      const genNumMatch = new RegExp(/generation-([0-9]+)-species/);
-      const latestGeneration = files.reduce((prev, curr) => {
-        const currMatch = curr.match(genNumMatch);
-        const currGenerationNumber = currMatch[1];
-        if (prev > parseInt(currGenerationNumber)) {
-          return prev;
-        }
-        return currGenerationNumber;
-      });
+      const latestGeneration = getLatestGeneration(files);
       return {
         id: folder,
         lastUpdate: folderStats.mtime,
@@ -64,19 +103,14 @@ router
     console.log(`Species id: ${speciesId}`)
     const files = await fs.readdir(p.join(speciesFolder, speciesId));
     console.log("Total Files: ", files.length)
-    const genNumMatch = new RegExp(/generation-([0-9]+)-species/);
-    const latestGeneration = files.reduce((prev, curr) => {
-      const prevMatch = prev.match(genNumMatch);
-      const prevGenerationNumber = prevMatch[1];
-      const currMatch = curr.match(genNumMatch);
-      const currGenerationNumber = currMatch[1];
-      if (parseInt(prevGenerationNumber) > parseInt(currGenerationNumber)) {
-        return prev;
-      }
-      return curr;
-    });
-    console.log("Latest generation is: ", latestGeneration)
-    const latestGenerationSpeciesJSON = await fs.readFile(p.join(speciesFolder, speciesId, latestGeneration));
+    const latestGenerationFile = getLatestGenerationFile(files);
+    if (!latestGenerationFile) {
+      ctx.status = 404;
+      ctx.body = { error: "No training data found for this species" };
+      return;
+    }
+    console.log("Latest generation is: ", latestGenerationFile)
+    const latestGenerationSpeciesJSON = await fs.readFile(p.join(speciesFolder, speciesId, latestGenerationFile));
     ctx.body = JSON.parse(latestGenerationSpeciesJSON);
     console.log("Response is: ", ctx.response)
   })

--- a/src/coordinator.js
+++ b/src/coordinator.js
@@ -16,6 +16,8 @@ const cluster = require('cluster');
 const async = require("async");
 const fs = require("fs");
 
+const isPrimaryProcess = cluster.isPrimary || cluster.isMaster;
+
 import Bot from './bot'
 import Battleground from './battleground'
 import Trainer from './trainer'
@@ -31,7 +33,7 @@ import log from './logger'
  * On first run of this file cluster.isMaster is true. There is only one master process. 
  * When a worker calls fork inside that fork cluster.isMaster will be false so the battle process begins
  */
-if (cluster.isMaster) {
+if (isPrimaryProcess) {
     trainerProcess();
 } else {
     battleProcess();
@@ -90,12 +92,46 @@ function startGenerationBattles(runId, trainer) {
 }
 
 function startRound(totalGenerations, genome1, genome2, callback) {
-    const worker = cluster.fork();
+    let settled = false;
+
+    const finalize = (results) => {
+        if (settled) {
+            return;
+        }
+        settled = true;
+        return callback(results);
+    };
+
+    let worker;
+
+    try {
+        worker = cluster.fork();
+    } catch (err) {
+        log.info(`Unable to start training worker: ${err.message}`);
+        return finalize(null);
+    }
+
     worker.on('message', (msg) => {
-        if (msg.type == 'results') {
+        if (msg.type === 'results') {
             handleResults(msg.data);
+        } else if (msg.type === 'error') {
+            log.info(`Worker reported an error: ${msg.data.message}`);
+            finalize(null);
         }
     });
+
+    worker.on('error', (err) => {
+        log.info(`Training worker failed: ${err.message}`);
+        finalize(null);
+    });
+
+    worker.on('exit', (code, signal) => {
+        if (!settled) {
+            log.debug(`Worker exited before returning results (code=${code}, signal=${signal})`);
+            finalize(null);
+        }
+    });
+
     worker.send({
         totalGenerations,
         genomes: [
@@ -105,33 +141,57 @@ function startRound(totalGenerations, genome1, genome2, callback) {
     });
 
     function handleResults(results) {
+        if (!results) {
+            genome1.addFitness(0);
+            return finalize(null);
+        }
+
         let botFitness = Trainer.calculateBotFitnessFromResults(results, totalGenerations);
         genome1.addFitness(botFitness);
-        worker.kill();
-        return callback(results);
+        return finalize(results);
     }
 }
 
 function battleProcess() {
-    process.on('message', (msg) => {
-        const bot1 = new Bot(1);
-        const genome1 = Genome.loadFromJSON(msg.genomes[0]);
-        bot1.loadGenome(genome1);
-
-        // Bot 2 just does random stuff
-        const bot2 = new Bot(2);
-        const genome2 = Genome.loadFromJSON(msg.genomes[1]);
-        bot2.loadGenome(genome2);
-        bot2.selectAIMethod(msg.totalGenerations);
-
-        const battleground = new Battleground()
-        battleground.addBots(bot1, bot2);
-        battleground.start((results) => {
-            process.send({
-                type: 'results',
-                data: results
-            });
+    process.on('uncaughtException', (err) => {
+        process.send({
+            type: 'error',
+            data: {
+                message: err.message,
+                stack: err.stack
+            }
         });
+    });
+
+    process.on('message', (msg) => {
+        try {
+            const bot1 = new Bot(1);
+            const genome1 = Genome.loadFromJSON(msg.genomes[0]);
+            bot1.loadGenome(genome1);
+
+            // Bot 2 just does random stuff
+            const bot2 = new Bot(2);
+            const genome2 = Genome.loadFromJSON(msg.genomes[1]);
+            bot2.loadGenome(genome2);
+            bot2.selectAIMethod(msg.totalGenerations);
+
+            const battleground = new Battleground()
+            battleground.addBots(bot1, bot2);
+            battleground.start((results) => {
+                process.send({
+                    type: 'results',
+                    data: results
+                });
+            });
+        } catch (err) {
+            process.send({
+                type: 'error',
+                data: {
+                    message: err.message,
+                    stack: err.stack
+                }
+            });
+        }
     });
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -33,6 +33,15 @@ var app = new Vue({
                 battle.call(this, speciesData);
             });
         },
+        async refreshSpecies() {
+            try {
+                const response = await fetch('/species');
+                const species = await response.json();
+                this.species = formatSpecies(sortSpecies(species));
+            } catch (err) {
+                console.error('Failed to refresh species list', err);
+            }
+        },
     },
     computed: {
         generation() {
@@ -55,10 +64,16 @@ var app = new Vue({
         }
     },
     async mounted() {
-        const response = await fetch('/species');
-        const species = await response.json();
-        this.species = formatSpecies(sortSpecies(species));
+        await this.refreshSpecies();
         this.loading = false;
+        this.refreshTimer = window.setInterval(() => {
+            this.refreshSpecies();
+        }, 5000);
+    },
+    beforeDestroy() {
+        if (this.refreshTimer) {
+            window.clearInterval(this.refreshTimer);
+        }
     }
 });
 
@@ -66,7 +81,7 @@ function sortSpecies(speciesData) {
     return speciesData.sort((a, b) => {
         const aLastUpdate = new Date(a.lastUpdate);
         const bLastUpdate = new Date(b.lastUpdate);
-        return aLastUpdate.getTime() < bLastUpdate.getTime();
+        return aLastUpdate.getTime() - bLastUpdate.getTime();
     });
 }
 

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,6 +1,8 @@
 let debugLogger = function(){};
 
-if (process.env.DEBUG) {
+const hasProcess = typeof process !== 'undefined' && process && process.env;
+
+if (hasProcess && process.env.DEBUG) {
   debugLogger = console.log;
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,5 @@ module.exports = {
   output: {
     filename: 'main.js',
     path: path.resolve(__dirname, 'dist')
-  },
-  node: { fs: 'empty' }
+  }
 };


### PR DESCRIPTION
Hello, thank you for sharing this project.

I made a few small compatibility fixes so the project can build and run more reliably on a modern Webpack 5 / Windows setup.

## Summary

- Removed the Webpack 5-incompatible `node.fs` configuration.
- Made browser-side logging safe when `process` is unavailable.
- Kept the `start` script cross-platform.
- Improved species generation loading and automatic refresh.
- Handled training worker failures so rounds do not hang indefinitely.

## Verification

The following commands pass locally:

```sh
npm run compile-browser
npm run compile-node